### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ CQL::
     
   err, err1 := conn.Client.SetCqlVersion("3.0.0")
   if err != nil || err1 != nil {
-    log.Println(err, err2)
+    log.Println(err, err1)
   }
 
   res, err2 := conn.Query(`


### PR DESCRIPTION
I was reading through the examples in the README and I noticed that the CQL example makes use of a variable before it's defined.

My apologies if this is in error, I've just started to work with Go this week.
