### PR TITLE
Change link to gocql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ A simple Cassandra client in go.  Currently runs against cassandra 1.2.x
 Alternate go clients to consider
     
 * https://github.com/carloscm/gossie
-* https://github.com/tux21b/gocql 
+* https://github.com/gocql/gocql
 * Or, a go cassandra connection pooling service https://github.com/samuraisam/cassbounce
 
 


### PR DESCRIPTION
[gocql](https://github.com/gocql/gocql) is now being maintained as a group. The old tux21b project is now just a personal fork of the gocql upstream.
